### PR TITLE
Add round to tax and net calculations

### DIFF
--- a/src/helpers/TaxExtractor.php
+++ b/src/helpers/TaxExtractor.php
@@ -46,7 +46,7 @@ class TaxExtractor
 	 */
 	public function getTaxTotal() : int
 	{
-		return (int)(($this->included + $this->excluded)*100);
+		return (int)round(($this->included + $this->excluded)*100);
 	}
 
 	/**
@@ -101,7 +101,7 @@ class TaxExtractor
 	 */
 	public function getTotalNet() : int
 	{
-		return (int)(($this->line->getTotal()*100)-$this->getTaxTotal());
+		return (int)round(($this->line->getTotal()*100)-$this->getTaxTotal());
 	}
 
 	/**


### PR DESCRIPTION
Tax, net and gross is calculated differently than Craft. Which creates a missmatch on total value between Craft order and Klarna. 

For example: On a order with a discount code generating a tax and net value that has more decimals then two. Current calculations use a INT parse which removes one decimals that in Craft is rounded up.