### PR TITLE
Add event that allows people to change the address format to their needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ KLARNA_PROD_PWD="XXXXXXXXXXXXXX"
 KLARNA_TEST_MODE_klarnaCheckout="true"
 ```
 
+### Formatting / changing the address
+If your set-up uses different fields for the addresses in Commerce, for instance when you store the house number separately from the streetname, you can hook into the address formatter to change the format before it gets sent to Klarna.
+
+The FormatAddressEvent contains two parameters, the `address` parameter that contains the formatted address and the `sourceAddress`, which contains the source Address model.
+```
+    use ellera\commerce\klarna\gateways\Base as KlarnaGateway;
+    
+    Event::on(
+        KlarnaGateway::class,
+        KlarnaGateway::EVENT_FORMAT_ADDRESS,
+        function(FormatAddressEvent $event) {
+            $event->address['street_address'] = "{$event->sourceAddress->address1} {$event->sourceAddress->address3}";
+        }
+    );
+```
 ## Troubleshooting
 
 #### I get 401 or 403 response when I turn off Test Mode

--- a/src/events/FormatAddressEvent.php
+++ b/src/events/FormatAddressEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ellera\commerce\klarna\events;
+
+use craft\commerce\models\Address;
+use yii\base\Event;
+
+class FormatAddressEvent extends Event
+{
+    /**
+     * @var array
+     */
+    public $address;
+
+    /**
+     * @var Address
+     */
+    public $sourceAddress;
+}

--- a/src/gateways/Base.php
+++ b/src/gateways/Base.php
@@ -11,6 +11,7 @@ use craft\commerce\models\Address;
 use craft\commerce\models\payments\BasePaymentForm;
 use craft\commerce\models\PaymentSource;
 use craft\commerce\models\Transaction;
+use ellera\commerce\klarna\events\FormatAddressEvent;
 use ellera\commerce\klarna\klarna\order\Refund;
 use ellera\commerce\klarna\klarna\order\Update;
 use craft\commerce\elements\Order as CraftOrder;
@@ -38,6 +39,8 @@ class Base extends Gateway
 {
     // Public Variables
     // =========================================================================
+
+    const EVENT_FORMAT_ADDRESS = 'formatAddress';
 
     /**
      * Setting: Title
@@ -451,7 +454,7 @@ class Base extends Gateway
      */
     public function formatAddress(Address $address, string $email = '') : array
     {
-        return [
+        $formattedAddress = [
             "organization_name" => $address->businessName,
             "given_name" => $address->firstName,
             "family_name" => $address->lastName,
@@ -465,6 +468,11 @@ class Base extends Gateway
             "phone" => $address->phone,
             "country" => $address->country->iso,
         ];
+
+        $event = new FormatAddressEvent(['address' => $formattedAddress, 'sourceAddress' => $address]);
+        $this->trigger(self::EVENT_FORMAT_ADDRESS, $event);
+
+        return $event->address;
     }
 
     /**


### PR DESCRIPTION
This PR allows developers to hook into the address field formatter and mutate fields to adjust them to fit their specific set-up. Fixes #54